### PR TITLE
feat(dynamodb): Turns on point-in-time recovery for tables

### DIFF
--- a/src/services/database/serverless.yml
+++ b/src/services/database/serverless.yml
@@ -82,6 +82,8 @@ resources:
         KeySchema:
           - AttributeName: postId
             KeyType: HASH
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
@@ -100,6 +102,8 @@ resources:
             KeyType: HASH
           - AttributeName: SK
             KeyType: RANGE
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1


### PR DESCRIPTION
## Purpose

This adds point-in-time recovery (PITR) to the `Table` and `PostsTable` resources.

#### Linked Issues to Close

Addresses the SecurityHub findings in [OY2-23722](https://qmacbis.atlassian.net/browse/OY2-23722) as well as:

https://qmacbis.atlassian.net/browse/OY2-23723
https://qmacbis.atlassian.net/browse/OY2-23724
https://qmacbis.atlassian.net/browse/OY2-23725
https://qmacbis.atlassian.net/browse/OY2-23726

## Approach

Followed the same apporach used in [seatool-compare](https://github.com/Enterprise-CMCS/seatool-compare/blob/master/src/services/mmdl/serverless.yml#L34).

## Assorted Notes/Considerations/Learning

More info available here for the very curious:

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-pointintimerecoveryspecification.html#cfn-dynamodb-table-pointintimerecoveryspecification-pointintimerecoveryenabled

https://docs.aws.amazon.com/securityhub/latest/userguide/dynamodb-controls.html#dynamodb-2